### PR TITLE
Replace use of get_file() with download_file()

### DIFF
--- a/yahoo.py
+++ b/yahoo.py
@@ -46,10 +46,10 @@ def archive_email(yga, reattach=True, save=True):
                 for attach in message['attachments']:
                     print "** Fetching attachment '%s'" % (attach['filename'],)
                     if 'link' in attach:
-                        atts[attach['filename']] = yga.get_file(attach['link'])
+                        atts[attach['filename']] = yga.download_file(attach['link'])
                     elif 'photoInfo' in attach:
                         photoinfo = get_best_photoinfo(attach['photoInfo'])
-                        atts[attach['filename']] = yga.get_file(photoinfo['displayURL'])
+                        atts[attach['filename']] = yga.download_file(photoinfo['displayURL'])
 
                     if save:
                         fname = "%s-%s" % (id, basename(attach['filename']))

--- a/yahoogroupsapi.py
+++ b/yahoogroupsapi.py
@@ -45,12 +45,7 @@ class YahooGroupsAPI:
         # For now check that we 'enough' cookies set.
         return len(self.s.cookies) > 2
 
-    def get_file(self, url):
-        r = self.s.get(url)
-        r.raise_for_status()
-        return r.content
-
-    def download_file(self, url, f, **args):
+    def download_file(self, url, f=None, **args):
         retries = 5
         while True:
             r = self.s.get(url, stream=True, **args)
@@ -61,6 +56,10 @@ class YahooGroupsAPI:
                 continue
             r.raise_for_status()
             break
+
+        if f is None:
+            return r.content
+
         for chunk in r.iter_content(chunk_size=4096):
             f.write(chunk)
 


### PR DESCRIPTION
The Yahoo Groups API is a bit flakey and often returns 400 errors. The `get_file()` method isn't robust enough to handle these 400 errors and will cause the script to exit immediately. The `download_file()` method however is able to handle retrying to get files, and with some minor modifications can be a drop-in replacement for `get_file()`, which should usually allow the script to complete.