### PR TITLE
Improve reliability of download process

### DIFF
--- a/yahoo.py
+++ b/yahoo.py
@@ -194,7 +194,7 @@ def archive_db(yga, group):
             break
         except requests.exceptions.HTTPError as err:
             json = None
-            if e.response.status_code == 403:
+            if err.response.status_code == 403:
                 # 403 error means Permission Denied. Retrying won't help.
                 break
             print "HTTP error (sleeping before retry, try %d: %s" % (i, err)

--- a/yahoo.py
+++ b/yahoo.py
@@ -119,7 +119,7 @@ def archive_photos(yga):
                 with open(fname, 'wb') as f:
                     yga.download_file(photoinfo['displayURL'], f)
 
-def archive_db(yga):
+def archive_db(yga, group):
     json = yga.database()
     n = 0
     nts = len(json['tables'])
@@ -128,7 +128,7 @@ def archive_db(yga):
         print "* Downloading database table '%s' (%d/%d)" % (table['name'], n, nts)
 
         name = basename(table['name']) + '.csv'
-        uri = "https://groups.yahoo.com/neo/groups/ulscr/database/%s/records/export?format=csv" % (table['tableId'],)
+        uri = "https://groups.yahoo.com/neo/groups/%s/database/%s/records/export?format=csv" % (group, table['tableId'])
         with open(name, 'w') as f:
             yga.download_file(uri, f)
 
@@ -198,4 +198,4 @@ if __name__ == "__main__":
                 archive_photos(yga)
         if args.database:
             with Mkchdir('databases'):
-                archive_db(yga)
+                archive_db(yga, args.group)


### PR DESCRIPTION
Yahoo sometimes throws back HTTP errors. Retrying after a short delay will result in a successful download.

This PR implements the retry logic.

Some groups have the Databases function disabled or locked for admins only. The 403 Forbidden error check detects this outcome and skips the download process. The alternative is that we enter the loop with the `json` variable unassigned and crash with an exception.