### PR TITLE
Pagination for messages retrieval

### DIFF
--- a/yahoo.py
+++ b/yahoo.py
@@ -52,60 +52,85 @@ def get_best_photoinfo(photoInfoArr, exclude=[]):
         return best
 
 
-def archive_email(yga, save=True, html=True):
+def archive_messages_metadata(yga):
+    logger = logging.getLogger('archive_message_metadata')
+    params = {'sortOrder': 'asc', 'direction': 1, 'count': 1000}
+
+    message_ids = []
+    next_page_start = float('inf')
+    page_count = 0
+
+    logger.info("Archiving message metadata...")
+
+    while next_page_start > 0:
+        msgs = yga.messages(**params)
+
+        with open("message_metadata_%s.json" % page_count, 'wb') as f:
+            json.dump(msgs, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=4)
+
+        next_page_start = params['start'] = msgs['nextPageStart']
+        message_ids += [msg['messageId'] for msg in msgs['messages']]
+        page_count += 1
+
+        logger.info("Archived message metadata records (%d of %d)", len(message_ids), msgs['totalRecords'])
+
+    return message_ids
+
+
+def archive_message_content(yga, id):
+    logger = logging.getLogger('archive_message_content')
+    logger.info("Fetching raw message #%d", id)
+    for i in range(TRIES):
+        try:
+            raw_json = yga.messages(id, 'raw')
+            with open("%s_raw.json" % (id,), 'wb') as f:
+                json.dump(raw_json, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=4)
+            break
+        except requests.exceptions.ReadTimeout:
+            logger.exception("Read timeout for raw message %d, retrying", id)
+            time.sleep(HOLDOFF)
+        except requests.exceptions.HTTPError:
+            logger.exception("Raw grab failed for message %d", id)
+            break
+
+    logger.info("Fetching html message #%d", id)
+    for i in range(TRIES):
+        try:
+            html_json = yga.messages(id)
+            with open("%s.json" % (id,), 'wb') as f:
+                json.dump(html_json, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=4)
+
+            if 'attachmentsInfo' in html_json:
+                with Mkchdir("%d_attachments" % id):
+                    process_single_attachment(yga, html_json['attachmentsInfo'])
+
+            break
+        except requests.exceptions.ReadTimeout:
+            logger.exception("Read timeout for html message %d, retrying", id)
+            time.sleep(HOLDOFF)
+        except requests.exceptions.HTTPError:
+            logger.exception("HTML grab failed for message %d", id)
+            break
+
+
+def archive_email(yga, message_subset=None):
     logger = logging.getLogger('archive_email')
     try:
-        msg_json = yga.messages()
+        yga.messages()
     except requests.exceptions.HTTPError as err:
         logger.error("User doesn't have permission to access Messages in this group", err.message)
         return
 
-    count = msg_json['totalRecords']
+    if message_subset is None:
+        message_subset = archive_messages_metadata(yga)
+        logger.info("Group has %s messages (maximum id: %s), fetching all", len(message_subset), message_subset[-1])
 
-    msg_json = yga.messages(count=count)
-    logger.info("Group has %s messages, got %s", count, msg_json['numRecords'])
-
-    for message in msg_json['messages']:
-        id = message['messageId']
-
-        logger.info("Fetching raw message #%d of %d", id, count)
-        for i in range(TRIES):
-            try:
-                raw_json = yga.messages(id, 'raw')
-                break
-            except requests.exceptions.ReadTimeout:
-                logger.error("Read timeout for raw message %d of %d, retrying", id, count)
-                time.sleep(HOLDOFF)
-            except requests.exceptions.HTTPError as err:
-                logger.error("Raw grab failed for message %d of %d", id, count)
-                break
-        if html:
-            logger.info("* Fetching html message #%d of %d", id, count)
-            for i in range(TRIES):
-                try:
-                    html_json = yga.messages(id)
-                    break
-                except requests.exceptions.ReadTimeout:
-                    logger.error("Read timeout for html message %d of %d, retrying", id, count)
-                    time.sleep(HOLDOFF)
-                except requests.exceptions.HTTPError:
-                    logger.error("HTML grab failed for message %d of %d", id, count)
-                    break
-
-        if save and message['hasAttachments']:
-            if 'attachments' not in message:
-                logger.warning("Yahoo says this message (%d of %d) has attachments, but I can't find any!", id, count)
-            else:
-                with Mkchdir("%d_attachments" % id):
-                    process_single_attachment(yga, message['attachments'])
-
-        with open("%s_raw.json" % (id,), 'wb') as f:
-            json.dump(raw_json, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=4)
-
-        if html:
-            with open("%s.json" % (id,), 'wb') as f:
-                json.dump(html_json, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=4)
-
+    for id in message_subset:
+        try:
+            archive_message_content(yga, id)
+        except Exception:
+            logger.exception("Failed to get message id: %d", id)
+            continue
 
 def process_single_attachment(yga, attach):
     logger = logging.getLogger(name="process_single_attachment")
@@ -576,12 +601,6 @@ if __name__ == "__main__":
     po.add_argument('-m', '--members', action='store_true',
                     help='Only archive members')
 
-    pe = p.add_argument_group(title='Email Options')
-    pe.add_argument('-s', '--no-save', action='store_true',
-                    help="Don't save email attachments as individual files")
-    pe.add_argument('--html', action='store_false',
-                    help="Don't save the non-raw version of message")
-
     pf = p.add_argument_group(title='Output Options')
     pf.add_argument('-w', '--warc', action='store_true',
                     help='Output WARC file of raw network requests. [Requires warcio package installed]')
@@ -620,7 +639,7 @@ if __name__ == "__main__":
 
         if args.email:
             with Mkchdir('email'):
-                archive_email(yga, save=(not args.no_save), html=args.html)
+                archive_email(yga)
         if args.files:
             with Mkchdir('files'):
                 archive_files(yga)


### PR DESCRIPTION
Fetch message metadata 1000 records at a time using the messages
endpoint pagination fields.
Split up achive_email function to more easily permit partial downloads
in future.

Fixes #15, #54 (finally)