### PR TITLE
Add configurable delays before requests

### DIFF
--- a/yahoo.py
+++ b/yahoo.py
@@ -701,6 +701,7 @@ if __name__ == "__main__":
 
     p.add_argument('-v', '--verbose', action='store_true')
     p.add_argument('--colour', '--color', action='store_true', help='Colour log output to terminal')
+    p.add_argument('--delay', '--delay', nargs='?', type=float, help='Minimum delay between requests')
 
     p.add_argument('group', type=str)
 
@@ -732,8 +733,9 @@ if __name__ == "__main__":
     headers = {}
     if args.user_agent:
         headers['User-Agent'] = args.user_agent
+    delay = 0.2 if args.delay is None else args.delay
 
-    yga = YahooGroupsAPI(args.group, cookie_jar, headers)
+    yga = YahooGroupsAPI(args.group, cookie_jar, headers, delay=delay)
 
     if not (args.email or args.files or args.photos or args.database or args.links or args.calendar or args.about or
             args.polls or args.attachments or args.members):

--- a/yahoogroupsapi.py
+++ b/yahoogroupsapi.py
@@ -43,9 +43,10 @@ class YahooGroupsAPI:
     ww = None
     http_context = dummy_contextmanager
 
-    def __init__(self, group, cookie_jar=None, headers={}):
+    def __init__(self, group, cookie_jar=None, headers={}, delay=0):
         self.s = requests.Session()
         self.group = group
+        self.delay = delay
 
         if cookie_jar:
             self.s.cookies = cookie_jar
@@ -73,6 +74,7 @@ class YahooGroupsAPI:
         with self.http_context(self.ww):
             retries = 5
             while True:
+                time.sleep(self.delay)
                 r = self.s.get(url, stream=True, verify=VERIFY_HTTPS, **args)
                 if r.status_code == 400 and retries > 0:
                     self.logger.info("Got 400 error for %s, will sleep and retry %d times", url, retries)
@@ -98,7 +100,7 @@ class YahooGroupsAPI:
                 uri_parts[4] = ''
 
             uri = "/".join(uri_parts)
-
+            time.sleep(self.delay)
             r = self.s.get(uri, params=opts, verify=VERIFY_HTTPS, allow_redirects=False, timeout=15)
             try:
                 r.raise_for_status()


### PR DESCRIPTION
This is to prevent hammering Yahoo to the point of getting lots of 500s.