### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Requirements:
 Usage:
 ```bash
 pip install -r requirements.txt
-./yahoo.py -ct "<T_cookie>" -cy "<Y_cookie>" "<groupid>"
+./yahoo.py -ct '<T_cookie>' -cy '<Y_cookie>' '<groupid>'
 ```
 
 You will need to get the `T` and `Y` cookie values from an authenticated


### PR DESCRIPTION
Under zsh and bash (on Mac OS) double quotes do not fully escape the `&` symbol. It works with a single quote.

Thank you for your work, it is invaluable.