### PR TITLE
requests.exceptions, not requests.exception

### DIFF
--- a/yahoo.py
+++ b/yahoo.py
@@ -650,7 +650,7 @@ def archive_calendar(yga):
         try:
             logger.info("Trying to get events between %s and %s", jsonStart, jsonEnd)
             calContentRaw = yga.download_file(calURL)
-        except requests.exception.HTTPError:
+        except requests.exceptions.HTTPError:
             logger.error("Unrecoverable error getting events between %s and %s: URL %s", jsonStart, jsonEnd, calURL)
             return
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "./yahoo.py", line 1023, in <module>
    archive_calendar(yga)
  File "./yahoo.py", line 653, in archive_calendar
    except requests.exception.HTTPError:
AttributeError: module 'requests' has no attribute 'exception'
```